### PR TITLE
Closes #9

### DIFF
--- a/lib/allure-cucumber/formatter.rb
+++ b/lib/allure-cucumber/formatter.rb
@@ -15,7 +15,7 @@ module AllureCucumber
     
     def before_feature(feature)
       @has_background = false
-      @tracker.feature_name =  feature.name.gsub!(/\n/, " ")
+      @tracker.feature_name =  feature.name.gsub(/\n/, " ")
       AllureRubyAdaptorApi::Builder.start_suite(@tracker.feature_name, :severity => :normal)
     end
 


### PR DESCRIPTION
### Fixes
- #9 : `gsub!` changed to `gsub` to prevent `nil` value if match fails. 
  [Here](https://github.com/allure-framework/allure-cucumber/blob/master/lib/allure-cucumber/formatter.rb#L18) if feature name was in single line then feature name was set as "" , causing non-unique suite_names for the the xml report. 

cc: @smecsia 
