### PR TITLE
Fix for zero duration in tests - Closes #12 and bumping version for new ...

### DIFF
--- a/lib/allure-cucumber/feature_tracker.rb
+++ b/lib/allure-cucumber/feature_tracker.rb
@@ -2,7 +2,7 @@ module AllureCucumber
   
   class FeatureTracker
 
-    attr_accessor :feature_name, :scenario_name, :step_name  
+    attr_accessor :feature_name, :scenario_name, :step_name, :scenario_started_at  
     @@tracker = nil
 
     def self.create

--- a/lib/allure-cucumber/formatter.rb
+++ b/lib/allure-cucumber/formatter.rb
@@ -38,6 +38,7 @@ module AllureCucumber
       unless @scenario_outline
         @tracker.scenario_name = (name.nil? || name == "") ? "Unnamed scenario" : name.split("\n")[0]
         AllureRubyAdaptorApi::Builder.start_test(@tracker.feature_name, @tracker.scenario_name, :feature => @tracker.feature_name, :story => @tracker.scenario_name)
+        @tracker.scenario_started_at = Time.now
         post_background_steps if  @has_background
       else
         @scenario_outline_name = (name.nil? || name == "") ? "Unnamed scenario" : name.split("\n")[0]
@@ -78,7 +79,7 @@ module AllureCucumber
     
     def after_steps(steps)
       return if @in_background || @scenario_outline
-      result = { status: steps.status, exception: steps.exception }
+      result = { :status => steps.status, :exception => steps.exception, :started_at => @tracker.scenario_started_at, :finished_at => Time.now }
       AllureRubyAdaptorApi::Builder.stop_test(@tracker.feature_name, @tracker.scenario_name, result)
     end
 
@@ -113,6 +114,7 @@ module AllureCucumber
         @exception = nil
         @tracker.scenario_name = "#{@scenario_outline_name} Example: #{table_row.name}"
         AllureRubyAdaptorApi::Builder.start_test(@tracker.feature_name, @tracker.scenario_name, :feature => @tracker.feature_name, :story => @tracker.scenario_name)
+        @tracker.scenario_started_at = Time.now
         post_background_steps if @has_background
         @current_row += 1
         @example_before_steps.each do |step| 
@@ -134,7 +136,7 @@ module AllureCucumber
           end      
           AllureRubyAdaptorApi::Builder.stop_step(@tracker.feature_name, @tracker.scenario_name, @tracker.step_name, step.status.to_sym)
         end
-        AllureRubyAdaptorApi::Builder.stop_test(@tracker.feature_name, @tracker.scenario_name, {:status => @scenario_status, :exception => @exception})
+        AllureRubyAdaptorApi::Builder.stop_test(@tracker.feature_name, @tracker.scenario_name, {:status => @scenario_status, :exception => @exception, :started_at => @tracker.scenario_started_at, :finished_at => Time.now })
       end
       @header_row = false if @header_row
     end

--- a/lib/allure-cucumber/version.rb
+++ b/lib/allure-cucumber/version.rb
@@ -1,5 +1,5 @@
 module AllureCucumber  
   module Version 
-    STRING = '0.4.1'
+    STRING = '0.4.2'
   end
 end


### PR DESCRIPTION
### Fix
-  #12 : zero duration in individual scenarios
### Change
- Bumping version for new gem release
### Testing
- Verified locally for `scenario` and `scenario_outline` 
- One caveat is that if `feature` contains only one `scenario` then duration of the `feature` will be slightly more (~.5  seconds) than `scenario` duration. I will analyze this check what improvements can be made in future  

@smecsia - Please review and let me know if it is good to merge
