### PR TITLE
Added  ENV['FEATURE_IDENTIFIER'] to feature name

### DIFF
--- a/lib/allure-cucumber/formatter.rb
+++ b/lib/allure-cucumber/formatter.rb
@@ -15,7 +15,8 @@ module AllureCucumber
     
     def before_feature(feature)
       @has_background = false
-      @tracker.feature_name =  feature.name.gsub(/\n/, " ")
+      feature_identifier = ENV['FEATURE_IDENTIFIER'] && "#{ENV['FEATURE_IDENTIFIER']} - "
+      @tracker.feature_name = "#{feature_identifier}#{feature.name.gsub(/\n/, " ")}"
       AllureRubyAdaptorApi::Builder.start_suite(@tracker.feature_name, :severity => :normal)
     end
 
@@ -66,7 +67,7 @@ module AllureCucumber
     end
 
     def after_step(step)
-      unless step.background? 
+      unless step.background?
         unless @scenario_outline
          AllureRubyAdaptorApi::Builder.stop_step(@tracker.feature_name, @tracker.scenario_name, @tracker.step_name, step.status.to_sym)
         else

--- a/lib/allure-cucumber/version.rb
+++ b/lib/allure-cucumber/version.rb
@@ -1,5 +1,5 @@
 module AllureCucumber  
   module Version 
-    STRING = '0.4.3'
+    STRING = '0.4.4'
   end
 end


### PR DESCRIPTION
## Changes
- Added prefix `ENV['FEATURE_IDENTIFIER']` to feature/suite name. This can be used to add something like browser name to features when it is run in multiple browsers for easy identification
- Bumped the version

@smecsia - Please review and let me know if it is good to be merged. 
