### PR TITLE
Add option to enable file attachments to cucumber scenarios

### DIFF
--- a/lib/allure-cucumber/dsl.rb
+++ b/lib/allure-cucumber/dsl.rb
@@ -1,9 +1,11 @@
 module AllureCucumber
   module DSL
 
-    def attach_file(title, file)
+    def attach_file(title, file, attach_to_step=true)
       @tracker = AllureCucumber::FeatureTracker.tracker
-      AllureRubyAdaptorApi::Builder.add_attachment(@tracker.feature_name, @tracker.scenario_name, :step => @tracker.step_name, :file => file, :title => title)
+      options = {:file => file, :title => title}
+      options.merge!(:step => @tracker.step_name) if attach_to_step
+      AllureRubyAdaptorApi::Builder.add_attachment(@tracker.feature_name, @tracker.scenario_name, options)
     end
 
   end


### PR DESCRIPTION
Optional argument added to "AllureCucumber::DSL.attach_file" method, that allows you to control attachment target: step or scenario. Default behaviour remain the same (files are attached to steps).