### PR TITLE
Feature: Added configuration to enable/disable report folder cleanup

### DIFF
--- a/lib/allure-cucumber.rb
+++ b/lib/allure-cucumber.rb
@@ -8,7 +8,7 @@ module AllureCucumber
   
   module Config
     class << self
-      attr_accessor :output_dir
+      attr_accessor :output_dir, :clean_dir
       
       DEFAULT_OUTPUT_DIR = 'gen/allure-results'
       

--- a/lib/allure-cucumber/formatter.rb
+++ b/lib/allure-cucumber/formatter.rb
@@ -12,8 +12,8 @@ module AllureCucumber
     POSSIBLE_STATUSES = ['passed', 'failed', 'pending', 'skipped', 'undefined']
     
     def initialize(step_mother, io, options)
-      dir = Pathname.new(AllureCucumber::Config.output_dir)      
-      FileUtils.rm_rf(dir)
+      dir = Pathname.new(AllureCucumber::Config.output_dir)
+      FileUtils.rm_rf(dir) unless AllureCucumber::Config.clean_dir == false
       FileUtils.mkdir_p(dir)
       @tracker = AllureCucumber::FeatureTracker.create
       @deferred_before_test_steps = []


### PR DESCRIPTION
Hi,

There is a race condition when using allure-cucumber in parallel which can result in losing test results for the current run. This is because every allure-cucumber process will do an rm-rf on the report directory. 


This PR avoids the race condition by allowing the user to disable this 'cleaning' rm-rf. It will be very helpful for folks who use parallel-tests.

``` ruby 
AllureCucumber.configure do |c|
  c.clean_dir  = false
end
```
If a user sets the flag to 'false' they must take on the burden of clearing the directory themselves.