### PR TITLE
Feature: Added ability to use Allure TMS / ISSUE / SEVERITY labels

### DIFF
--- a/lib/allure-cucumber.rb
+++ b/lib/allure-cucumber.rb
@@ -5,18 +5,34 @@ require 'allure-cucumber/dsl'
 require 'allure-cucumber/formatter'
 
 module AllureCucumber
-  
+
   module Config
     class << self
-      attr_accessor :output_dir, :clean_dir
-      
-      DEFAULT_OUTPUT_DIR = 'gen/allure-results'
-      
+
+      attr_accessor :output_dir, :clean_dir, :tms_prefix, :issue_prefix, :severity_prefix
+
+      DEFAULT_OUTPUT_DIR      = 'gen/allure-results'
+      DEFAULT_TMS_PREFIX      = '@TMS:'
+      DEFAULT_ISSUE_PREFIX    = '@ISSUE:'
+      DEFAULT_SEVERITY_PREFIX = '@SEVERITY:'
+
       def output_dir
         @output_dir || DEFAULT_OUTPUT_DIR
       end
-      
-    end 
+
+      def tms_prefix
+        @tms_prefix || DEFAULT_TMS_PREFIX
+      end
+
+      def issue_prefix
+        @issue_prefix || DEFAULT_ISSUE_PREFIX
+      end
+
+      def severity_prefix
+        @severity_prefix || DEFAULT_SEVERITY_PREFIX
+      end
+
+    end
   end
 
   class << self
@@ -27,5 +43,5 @@ module AllureCucumber
       end
     end
   end
-  
+
 end


### PR DESCRIPTION
Hi,

The user can now set the config block to indicate a prefix for TMS, ISSUE, and SEVERITY labels. allure-cucumber will now read all of the cucumber tags before a scenario and if it finds a match, it will be included / displayed in the report. 

``` ruby
AllureCucumber.configure do |c|
  c.output_dir      = 'report/allure-results/'
  c.tms_prefix      = '@HIPTEST:'
  c.issue_prefix    = '@JIRA:'
  c.severity_prefix = '@SEVERITY:'
end  
```

Example in use: 

``` ruby
  @SEVERITY:trivial @JIRA:YZZ-100
  Scenario: Leave First Name Blank
    When I register an account without a first name
    Then exactly (1) [validation_error] should be visible

  @JIRA:CC-42 @HIPTEST:9901 @SEVERITY:critical
  Scenario: Leave Last Name Blank
    When I register an account without a last name
    Then exactly (1) [validation_error] should be visible
```

If the user does not provide any configuration, then allure-cucumber will use the following defaults

``` ruby
module AllureCucumber

  module Config
    class << self
      attr_accessor :output_dir, :tms_prefix, :issue_prefix, :severity_prefix

      DEFAULT_OUTPUT_DIR      = 'gen/allure-results'
      DEFAULT_TMS_PREFIX      = '@TMS:'
      DEFAULT_ISSUE_PREFIX    = '@ISSUE:'
      DEFAULT_SEVERITY_PREFIX = '@SEVERITY:'

      def output_dir
        @output_dir || DEFAULT_OUTPUT_DIR
      end

      def tms_prefix
        @tms_prefix || DEFAULT_TMS_PREFIX
      end

      def issue_prefix
        @issue_prefix || DEFAULT_ISSUE_PREFIX
      end

      def severity_prefix
        @severity_prefix || DEFAULT_SEVERITY_PREFIX
      end

    end
  end
```
Note, i marked this WIP as the PR is more of a proof of concept. The code works, but its ugly and not scalable. 