### PR TITLE
Fix report generation for scenario outline

### DIFF
--- a/lib/allure-cucumber/formatter.rb
+++ b/lib/allure-cucumber/formatter.rb
@@ -100,8 +100,8 @@ module AllureCucumber
     def after_table_row(table_row)
       unless @multiline_arg
         if @scenario_outline && !@header_row 
-          result = test_result(table_row)
-          stop_test(result)
+          @result = test_result(table_row)
+          stop_test(@result)
         end
         @header_row = false
       end


### PR DESCRIPTION
allure-cucumber fails for scenario outline with an error: 

```
undefined method `[]=' for nil:NilClass (NoMethodError)
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/allure-cucumber-0.5.6/lib/allure-cucumber/formatter.rb:82:in `after_scenario'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/allure-cucumber-0.5.6/lib/allure-cucumber/formatter.rb:87:in `after_feature_element'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-2.4.0/lib/cucumber/formatter/ignore_missing_messages.rb:10:in `method_missing'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-2.4.0/lib/cucumber/formatter/legacy_api/adapter.rb:622:in `after'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-2.4.0/lib/cucumber/formatter/legacy_api/adapter.rb:309:in `after'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-2.4.0/lib/cucumber/formatter/legacy_api/adapter.rb:123:in `after'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-2.4.0/lib/cucumber/formatter/legacy_api/adapter.rb:52:in `done'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-2.4.0/lib/cucumber/formatter/fanout.rb:16:in `block in method_missing'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-2.4.0/lib/cucumber/formatter/fanout.rb:15:in `each'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-2.4.0/lib/cucumber/formatter/fanout.rb:15:in `method_missing'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-core-1.5.0/lib/cucumber/core/test/runner.rb:40:in `done'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-core-1.5.0/lib/cucumber/core/filter.rb:61:in `done'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-core-1.5.0/lib/cucumber/core/filter.rb:61:in `done'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-core-1.5.0/lib/cucumber/core/filter.rb:61:in `done'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-core-1.5.0/lib/cucumber/core/filter.rb:61:in `done'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-core-1.5.0/lib/cucumber/core/filter.rb:61:in `done'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-core-1.5.0/lib/cucumber/core/filter.rb:61:in `done'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-2.4.0/lib/cucumber/filters/quit.rb:17:in `done'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-core-1.5.0/lib/cucumber/core/test/filters/locations_filter.rb:19:in `done'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-core-1.5.0/lib/cucumber/core/filter.rb:61:in `done'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-core-1.5.0/lib/cucumber/core/test/filters/tag_filter.rb:18:in `done'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-core-1.5.0/lib/cucumber/core/compiler.rb:23:in `done'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-core-1.5.0/lib/cucumber/core/gherkin/parser.rb:35:in `done'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-core-1.5.0/lib/cucumber/core.rb:29:in `parse'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-core-1.5.0/lib/cucumber/core.rb:18:in `compile'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-2.4.0/lib/cucumber/runtime.rb:67:in `run!'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-2.4.0/lib/cucumber/cli/main.rb:32:in `execute!'
/Users/bayandin/.rvm/gems/ruby-2.1.5/gems/cucumber-2.4.0/bin/cucumber:8:in `<top (required)>'
/Users/bayandin/.rvm/gems/ruby-2.1.5/bin/cucumber:22:in `load'
/Users/bayandin/.rvm/gems/ruby-2.1.5/bin/cucumber:22:in `<top (required)>'
```

because `@result` is nil.