### PR TITLE
Reset @before_hook_exception in stop_test to prevent misleading exceptions in next failing scenarios

### DIFF
--- a/lib/allure-cucumber/formatter.rb
+++ b/lib/allure-cucumber/formatter.rb
@@ -232,6 +232,7 @@ module AllureCucumber
         @deferred_before_test_steps = []
         @deferred_after_test_steps = []
         @scenario_tags = {}
+        @before_hook_exception = nil
       end
     end
     


### PR DESCRIPTION
Without this fix all next failing scenarios will have exception, contained in this variable.
Bug was created by me in https://github.com/allure-framework/allure-cucumber/pull/38. Sorry.