### PR TITLE
add 'AfterStep hook' to ignored step names

### DIFF
--- a/lib/allure-cucumber/formatter.rb
+++ b/lib/allure-cucumber/formatter.rb
@@ -122,7 +122,8 @@ module AllureCucumber
         if (!@before_hook_exception) && result.methods.include?(:exception)
           @before_hook_exception = result.exception
         end
-      elsif test_step.name != 'After hook'
+      end
+      if !TEST_HOOK_NAMES_TO_IGNORE.include?(test_step.name)
         if @tracker.scenario_name
           status = step_status(result)
           stop_step(status)

--- a/lib/allure-cucumber/formatter.rb
+++ b/lib/allure-cucumber/formatter.rb
@@ -7,7 +7,7 @@ module AllureCucumber
 
     include AllureCucumber::DSL
     
-    TEST_HOOK_NAMES_TO_IGNORE = ['Before hook', 'After hook']
+    TEST_HOOK_NAMES_TO_IGNORE = ['Before hook', 'After hook', 'AfterStep hook']
     ALLOWED_SEVERITIES = ['blocker', 'critical', 'normal', 'minor', 'trivial']
     POSSIBLE_STATUSES = ['passed', 'failed', 'pending', 'skipped', 'undefined']
 


### PR DESCRIPTION
I don't know about other types of hooks that are not ignored by formatter yet but they may exist.