### PR TITLE
Add (constructed) step_id to @tracker in order to deal with duplicate steps in scenario

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,3 @@
 require "bundler/gem_tasks"
+
+task :default => :build

--- a/allure-cucumber.gemspec
+++ b/allure-cucumber.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'cucumber' , '>= 2.0.0'
-  spec.add_dependency 'allure-ruby-adaptor-api'
+  spec.add_dependency 'allure-ruby-adaptor-api', '>= 0.7.1'
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"

--- a/lib/allure-cucumber/feature_tracker.rb
+++ b/lib/allure-cucumber/feature_tracker.rb
@@ -2,7 +2,7 @@ module AllureCucumber
   
   class FeatureTracker
 
-    attr_accessor :feature_name, :scenario_name, :step_name, :step_line
+    attr_accessor :feature_name, :scenario_name, :step_name, :step_id
     @@tracker = nil
 
     def self.create

--- a/lib/allure-cucumber/feature_tracker.rb
+++ b/lib/allure-cucumber/feature_tracker.rb
@@ -2,7 +2,7 @@ module AllureCucumber
   
   class FeatureTracker
 
-    attr_accessor :feature_name, :scenario_name, :step_name
+    attr_accessor :feature_name, :scenario_name, :step_name, :step_line
     @@tracker = nil
 
     def self.create

--- a/lib/allure-cucumber/formatter.rb
+++ b/lib/allure-cucumber/formatter.rb
@@ -109,7 +109,9 @@ module AllureCucumber
     def before_test_step(test_step)
       if !TEST_HOOK_NAMES_TO_IGNORE.include?(test_step.name) 
         if @tracker.scenario_name
-          @tracker.step_name = test_step.name
+          step_location =  @deferred_before_test_steps[index][:step].location.lines.first.to_s
+          step_name = @deferred_before_test_steps[index][:step].name
+          @tracker.step_name = "#{step_name} | line #{step_location}"
           start_step
         else
           @deferred_before_test_steps << {:step => test_step, :timestamp => Time.now}
@@ -216,7 +218,9 @@ module AllureCucumber
 
     def post_deferred_steps
       @deferred_before_test_steps.size.times do |index|
-        @tracker.step_name = @deferred_before_test_steps[index][:step].name 
+        step_location =  @deferred_before_test_steps[index][:step].location.lines.first.to_s
+        step_name = @deferred_before_test_steps[index][:step].name
+        @tracker.step_name = "#{step_name} | line #{step_location}"
         start_step
         multiline_arg = @deferred_before_test_steps[index][:multiline_arg]
         attach_multiline_arg_to_file(multiline_arg) if multiline_arg

--- a/lib/allure-cucumber/formatter.rb
+++ b/lib/allure-cucumber/formatter.rb
@@ -111,7 +111,7 @@ module AllureCucumber
         if @tracker.scenario_name
           step_location =  @deferred_before_test_steps[index][:step].location.lines.first.to_s
           step_name = @deferred_before_test_steps[index][:step].name
-          @tracker.step_line = step_location
+          @tracker.step_id = "#{@tracker.feature_name}-#{step_name}-#{step_location}"
           @tracker.step_name = step_name
           start_step
         else
@@ -221,7 +221,7 @@ module AllureCucumber
       @deferred_before_test_steps.size.times do |index|
         step_location =  @deferred_before_test_steps[index][:step].location.lines.first.to_s
         step_name = @deferred_before_test_steps[index][:step].name
-        @tracker.step_line = step_location
+        @tracker.step_id = "#{@tracker.feature_name}-#{step_name}-#{step_location}"
         @tracker.step_name = step_name
         start_step
         multiline_arg = @deferred_before_test_steps[index][:multiline_arg]
@@ -247,12 +247,12 @@ module AllureCucumber
       end
     end
 
-    def start_step(step_name = @tracker.step_name, step_line = @tracker.step_line)
-      AllureRubyAdaptorApi::Builder.start_step(@tracker.feature_name, @tracker.scenario_name, step_name, step_line)
+    def start_step(step_name = @tracker.step_name, step_id = @tracker.step_id)
+      AllureRubyAdaptorApi::Builder.start_step(@tracker.feature_name, @tracker.scenario_name, step_name, step_id)
     end
 
-    def stop_step(status, step_name = @tracker.step_name, step_line = @tracker.step_line)
-      AllureRubyAdaptorApi::Builder.stop_step(@tracker.feature_name, @tracker.scenario_name, step_name, step_line, status)
+    def stop_step(status, step_name = @tracker.step_name, step_id = @tracker.step_id)
+      AllureRubyAdaptorApi::Builder.stop_step(@tracker.feature_name, @tracker.scenario_name, step_name, step_id, status)
     end
 
   end

--- a/lib/allure-cucumber/formatter.rb
+++ b/lib/allure-cucumber/formatter.rb
@@ -109,9 +109,9 @@ module AllureCucumber
     def before_test_step(test_step)
       if !TEST_HOOK_NAMES_TO_IGNORE.include?(test_step.name) 
         if @tracker.scenario_name
-          step_location =  @deferred_before_test_steps[index][:step].location.lines.first.to_s
-          step_name = @deferred_before_test_steps[index][:step].name
-          @tracker.step_id = "#{@tracker.feature_name}-#{step_name}-#{step_location}"
+          step_location =  test_step.location.lines.first.to_s
+          step_name = test_step.name
+          @tracker.step_id = "#{@tracker.feature_name}-#{@tracker.scenario_name}-#{step_name}-#{step_location}"
           @tracker.step_name = step_name
           start_step
         else
@@ -221,7 +221,7 @@ module AllureCucumber
       @deferred_before_test_steps.size.times do |index|
         step_location =  @deferred_before_test_steps[index][:step].location.lines.first.to_s
         step_name = @deferred_before_test_steps[index][:step].name
-        @tracker.step_id = "#{@tracker.feature_name}-#{step_name}-#{step_location}"
+        @tracker.step_id = "#{@tracker.feature_name}-#{@tracker.scenario_name}-#{step_name}-#{step_location}"
         @tracker.step_name = step_name
         start_step
         multiline_arg = @deferred_before_test_steps[index][:multiline_arg]

--- a/lib/allure-cucumber/formatter.rb
+++ b/lib/allure-cucumber/formatter.rb
@@ -111,7 +111,8 @@ module AllureCucumber
         if @tracker.scenario_name
           step_location =  @deferred_before_test_steps[index][:step].location.lines.first.to_s
           step_name = @deferred_before_test_steps[index][:step].name
-          @tracker.step_name = "#{step_name} | line #{step_location}"
+          @tracker.step_line = step_location
+          @tracker.step_name = step_name
           start_step
         else
           @deferred_before_test_steps << {:step => test_step, :timestamp => Time.now}
@@ -220,7 +221,8 @@ module AllureCucumber
       @deferred_before_test_steps.size.times do |index|
         step_location =  @deferred_before_test_steps[index][:step].location.lines.first.to_s
         step_name = @deferred_before_test_steps[index][:step].name
-        @tracker.step_name = "#{step_name} | line #{step_location}"
+        @tracker.step_line = step_location
+        @tracker.step_name = step_name
         start_step
         multiline_arg = @deferred_before_test_steps[index][:multiline_arg]
         attach_multiline_arg_to_file(multiline_arg) if multiline_arg
@@ -244,15 +246,14 @@ module AllureCucumber
         @before_hook_exception = nil
       end
     end
-    
-    def start_step(step_name = @tracker.step_name)
-      AllureRubyAdaptorApi::Builder.start_step(@tracker.feature_name, @tracker.scenario_name, step_name) 
+
+    def start_step(step_name = @tracker.step_name, step_line = @tracker.step_line)
+      AllureRubyAdaptorApi::Builder.start_step(@tracker.feature_name, @tracker.scenario_name, step_name, step_line)
     end
 
-    def stop_step(status, step_name = @tracker.step_name)
-      AllureRubyAdaptorApi::Builder.stop_step(@tracker.feature_name, @tracker.scenario_name, step_name, status) 
+    def stop_step(status, step_name = @tracker.step_name, step_line = @tracker.step_line)
+      AllureRubyAdaptorApi::Builder.stop_step(@tracker.feature_name, @tracker.scenario_name, step_name, step_line, status)
     end
-    
-  end  
+
+  end
 end
-

--- a/lib/allure-cucumber/version.rb
+++ b/lib/allure-cucumber/version.rb
@@ -1,5 +1,5 @@
-module AllureCucumber  
-  module Version 
-    STRING = '0.6.0'
+module AllureCucumber
+  module Version
+    STRING = '0.6.1'
   end
 end


### PR DESCRIPTION
## What does this do?
* Appending line number to step_name, since step_name is being used as a key, this will create the uniqueness of the step inside of the scenario.

## What does this fix?
* Previously scenarios that had duplicate steps would not be displayed correctly in XML or in HTML reports and reports from Jenkins plugin for Allure.

## Other Notes
* Another PR is being created for `allure-ruby-commons` which will parse out this line number for display in XML and reports, this line number is ONLY being added temporarily in order to differentiate duplicate steps.

Relates to https://github.com/allure-framework/allure-ruby-commons/pull/30