### PR TITLE
Tag and test location showing in report

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in allure-cucumber.gemspec
 gemspec
+gem 'allure-ruby-adaptor-api', :git => 'https://github.com/serhatbolsu/allure-ruby-commons.git', :branch => 'master'

--- a/allure-cucumber.gemspec
+++ b/allure-cucumber.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'cucumber' , '>= 2.0.0'
-  spec.add_dependency 'allure-ruby-adaptor-api', '>= 0.7.2'
+  spec.add_dependency 'allure-ruby-adaptor-api'
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"

--- a/allure-cucumber.gemspec
+++ b/allure-cucumber.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'cucumber' , '>= 2.0.0'
-  spec.add_dependency 'allure-ruby-adaptor-api'
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"

--- a/lib/allure-cucumber/feature_tracker.rb
+++ b/lib/allure-cucumber/feature_tracker.rb
@@ -1,8 +1,7 @@
 module AllureCucumber
   
   class FeatureTracker
-
-    attr_accessor :feature_name, :scenario_name, :step_name, :step_id
+    attr_accessor :feature_name, :scenario_name, :step_name, :step_id, :file_location
     @@tracker = nil
 
     def self.create

--- a/lib/allure-cucumber/formatter.rb
+++ b/lib/allure-cucumber/formatter.rb
@@ -27,7 +27,6 @@ module AllureCucumber
     def before_feature(feature)
       feature_identifier = ENV['FEATURE_IDENTIFIER'] && "#{ENV['FEATURE_IDENTIFIER']} - "
       @tracker.feature_name = "#{feature_identifier}#{feature.name.gsub(/\n/, " ")}"
-      @tracker.file_location = feature.location.to_s
       @builder.start_suite(@tracker.feature_name)
     end
 
@@ -66,7 +65,7 @@ module AllureCucumber
     end
 
     def before_test_case(test_case)
-      # not used now, but keeping for later
+      @tracker.file_location = test_case.location.to_s
     end
 
     # Start the test for normal scenarios

--- a/lib/allure-cucumber/formatter.rb
+++ b/lib/allure-cucumber/formatter.rb
@@ -218,7 +218,7 @@ module AllureCucumber
         @scenario_tags[:feature] = @tracker.feature_name
         @scenario_tags[:story]   = @tracker.scenario_name
         #@scenario_tags[:severity] = 'normal'
-        @builder.start_test(@tracker.feature_name, @tracker.scenario_name, @scenario_tags)
+        @builder.start_test(@tracker.feature_name, @tracker.scenario_name, @scenario_tags, @tracker.file_location)
         post_deferred_steps
       end
     end


### PR DESCRIPTION
- Added tags as labels, able to handle multiple tags
- Added test location as description ( it was not used before)
- Added `Afterstep Hook` 
Warning: this is still a deprecated implementation of `formatters`. Before this library, first allure-ruby-common required to be changed to support cucumber 4